### PR TITLE
Commit RLA-15A inicial con sintonizacion consumo de API Register y Login

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/refactoringlifeacademy/data/dto/request/RegisterRequest.kt
+++ b/app/src/main/java/com/example/refactoringlifeacademy/data/dto/request/RegisterRequest.kt
@@ -1,6 +1,8 @@
 package com.example.refactoringlifeacademy.data.dto.request
 
+import com.google.gson.annotations.SerializedName
+
 data class RegisterRequest(
     val email: String,
-    val password: String,
+    val password: String
 )

--- a/app/src/main/java/com/example/refactoringlifeacademy/data/repository/LoginRepository.kt
+++ b/app/src/main/java/com/example/refactoringlifeacademy/data/repository/LoginRepository.kt
@@ -7,7 +7,7 @@ import retrofit2.Response
 
 class LoginRepository(private val service: LoginServiceImp = LoginServiceImp()) {
 
-    fun loginUser(request: LoginRequest) :Response<LoginResponse>{
+    suspend fun loginUser(request: LoginRequest) :Response<LoginResponse>{
         return service.loginUser(request)
     }
 

--- a/app/src/main/java/com/example/refactoringlifeacademy/data/repository/RegisterRepository.kt
+++ b/app/src/main/java/com/example/refactoringlifeacademy/data/repository/RegisterRepository.kt
@@ -7,7 +7,7 @@ import retrofit2.Response
 
 class RegisterRepository(private val service: RegisterServiceImplement = RegisterServiceImplement()) {
 
-    fun registerUser(request: RegisterRequest) : Response<RegisterResponse>{
+    suspend fun registerUser(request: RegisterRequest) : Response<RegisterResponse>{
         return service.registerUser(request)
     }
 }

--- a/app/src/main/java/com/example/refactoringlifeacademy/data/service/LoginService.kt
+++ b/app/src/main/java/com/example/refactoringlifeacademy/data/service/LoginService.kt
@@ -8,5 +8,5 @@ import retrofit2.http.POST
 
 interface LoginService {
     @POST("api/v1/auth/login")
-    fun loginUser(@Body request: LoginRequest): Response<LoginResponse>
+    suspend fun loginUser(@Body request: LoginRequest): Response<LoginResponse>
 }

--- a/app/src/main/java/com/example/refactoringlifeacademy/data/service/LoginServiceImp.kt
+++ b/app/src/main/java/com/example/refactoringlifeacademy/data/service/LoginServiceImp.kt
@@ -15,7 +15,7 @@ class LoginServiceImp {
 
     private val service = retrofit.create<LoginService>()
 
-    fun loginUser(request: LoginRequest): Response<LoginResponse>{
+    suspend fun loginUser(request: LoginRequest): Response<LoginResponse>{
         return service.loginUser(request)
     }
 }

--- a/app/src/main/java/com/example/refactoringlifeacademy/data/service/RegisterService.kt
+++ b/app/src/main/java/com/example/refactoringlifeacademy/data/service/RegisterService.kt
@@ -7,6 +7,6 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface RegisterService {
-    @POST("auth/register")
-    fun registerUser(@Body request: RegisterRequest): Response<RegisterResponse>
+    @POST("api/v1/auth/register")
+    suspend fun registerUser(@Body request: RegisterRequest): Response<RegisterResponse>
 }

--- a/app/src/main/java/com/example/refactoringlifeacademy/data/service/RegisterServiceImplement.kt
+++ b/app/src/main/java/com/example/refactoringlifeacademy/data/service/RegisterServiceImplement.kt
@@ -1,6 +1,5 @@
 package com.example.refactoringlifeacademy.data.service
 
-import com.example.refactoringlifeacademy.R
 import com.example.refactoringlifeacademy.data.dto.request.RegisterRequest
 import com.example.refactoringlifeacademy.data.dto.response.RegisterResponse
 import retrofit2.Response
@@ -9,16 +8,14 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.create
 
 class RegisterServiceImplement() {
-    private val baseUrl: String = R.string.base_url.toString()
     private val retrofit = Retrofit.Builder()
-        //.baseUrl("https://api-users-c9xg.onrender.com/")
-        .baseUrl(baseUrl)
+        .baseUrl("https://api-users-c9xg.onrender.com/")
         .addConverterFactory(GsonConverterFactory.create())
         .build()
 
     private val service = retrofit.create<RegisterService>()
 
-    fun registerUser(request: RegisterRequest): Response<RegisterResponse> {
+    suspend fun registerUser(request: RegisterRequest): Response<RegisterResponse> {
         return service.registerUser(request)
     }
 }

--- a/app/src/main/java/com/example/refactoringlifeacademy/ui/login/presenter/LoginActivity.kt
+++ b/app/src/main/java/com/example/refactoringlifeacademy/ui/login/presenter/LoginActivity.kt
@@ -26,7 +26,6 @@ class LoginActivity : AppCompatActivity() {
         observer()
         activateButton()
         initListeners()
-
     }
 
     private fun initListeners() {
@@ -46,13 +45,14 @@ class LoginActivity : AppCompatActivity() {
             finish()
         }
 
+        binding.btnEnter.isEnabled = false
+
         binding.btnEnter.setOnClickListener {
             val email = binding.etEmail.text.toString()
             val password = binding.etPassword.text.toString()
             viewModel.loginUser(email, password)
         }
     }
-
 
     private fun observer() {
         viewModel.validationFields.observe(this) { isValid ->

--- a/app/src/main/java/com/example/refactoringlifeacademy/ui/login/viewmodel/ViewModelLogin.kt
+++ b/app/src/main/java/com/example/refactoringlifeacademy/ui/login/viewmodel/ViewModelLogin.kt
@@ -27,9 +27,6 @@ class ViewModelLogin(private val repository: LoginRepository = LoginRepository()
 
     fun loginUser(email: String, password: String) {
         CoroutineScope(Dispatchers.IO).launch {
-            val isValid = checkUserLogin(email, password)
-            _validateData.postValue(isValid)
-
             val response = repository.loginUser(LoginRequest(email, password))
         }
     }

--- a/app/src/main/java/com/example/refactoringlifeacademy/ui/register/presenter/RegisterActivity.kt
+++ b/app/src/main/java/com/example/refactoringlifeacademy/ui/register/presenter/RegisterActivity.kt
@@ -55,11 +55,11 @@ class RegisterActivity : AppCompatActivity() {
     }
 
     private fun registerButton() {
-        val email = binding.etEmail.text.toString()
-        val password = binding.etPassword.text.toString()
-        val confirmPassword = binding.etConfirmPassword.text.toString()
-        viewModel.validateEmailPassword(email, password, confirmPassword)
+        binding.buttonRegister.isEnabled = false
         binding.buttonRegister.setOnClickListener {
+            val email = binding.etEmail.text.toString()
+            val password = binding.etPassword.text.toString()
+            val confirmPassword = binding.etConfirmPassword.text.toString()
             if (password == confirmPassword) {
                 val requestRegister = RegisterRequest(email, password)
                 viewModel.registerUser(requestRegister)

--- a/app/src/main/java/com/example/refactoringlifeacademy/ui/register/viewmodel/RegisterViewModel.kt
+++ b/app/src/main/java/com/example/refactoringlifeacademy/ui/register/viewmodel/RegisterViewModel.kt
@@ -11,10 +11,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class RegisterViewModel(private val regRepository: RegisterRepository = RegisterRepository()) : ViewModel() {
+class RegisterViewModel(private val regRepository: RegisterRepository = RegisterRepository()) :
+    ViewModel() {
     private val _isFormValid = MutableLiveData<Boolean>()
     val isFormValid: LiveData<Boolean> = _isFormValid
-
 
     fun validateEmailPassword(email: String, password: String, confirmPassword: String) {
         CoroutineScope(Dispatchers.IO).launch {


### PR DESCRIPTION
PR asociado a la sintonizacion y prueba del consumo del API Register y Login. Fundamentalmente los cambios subidos estan relacionados con agregar a las funciones del consumo del API el atributo suspend ya que estan dentro de una corrutina, se elimino la forma de como se consumia el recurso string en el consumo para la base url, pues habia que pasar el contexto para poder usar la funcion getstring que obtiene ese recurso e implicaba cambios en diferentes partes de la aplicacion (esto pudiera quedar para una investigacion posterior ya que seria de mucha utilidad), se elimino el chequeo de los campos de email y password en la corrutina que invoca el onclick en primer lugar porque no tiene sentido chequear los campos despues que se le pueda dar click al boton si es mandatorio que el boton solo se active despues que este chequeo esta ok y en segundo lugar porque habia un observer sobre el campo que cambiaba el estado que impedia el consumo del API, ese observer se dejo en el Login Activity pues sera necesario en el control de estados. Ademas se inicializaron losbotones de Login y Register como deshabilitados pues si se inicializan habilitados sin chequear los campos se les pudiera hacer click ya que lo que desencadena el chequeo de los campos son los textwatch puesto sobre los cambios en esos campos. 

Este PR tiene un solo commit que le puse RLA-15A y con el cual hare una tarjeta en el Trello.